### PR TITLE
fixed build failure

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -127,7 +127,6 @@ func (vb *VersionsBundle) SnowImages() []Image {
 	return i
 }
 
-<<<<<<< HEAD
 func (vb *VersionsBundle) TinkerbellImages() []Image {
 	return []Image{
 		vb.Tinkerbell.ClusterAPIController,
@@ -220,6 +219,6 @@ func (vb *VersionsBundle) Charts() map[string]*Image {
 	return map[string]*Image{
 		"cilium":                &vb.Cilium.HelmChart,
 		"eks-anywhere-packages": &vb.PackageController.HelmChart,
-		"tinkerbell-chart": &vb.Tinkerbell.TinkerbellStack.TinkebellChart,
+		"tinkerbell-chart":      &vb.Tinkerbell.TinkerbellStack.TinkebellChart,
 	}
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -73,6 +73,7 @@ T_VSPHERE_CLUSTER_IP_POOL # comma-separated list of CP ip addresses
  T_NUTANIX_CONTROL_PLANE_ENDPOINT_IP
  T_NUTANIX_POD_CIDR
  T_NUTANIX_SERVICE_CIDR
+ T_NUTANIX_ADDITIONAL_TRUST_BUNDLE
  ```
 
 ### Tests upgrading from old release

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -384,35 +384,32 @@ func TestSnowKubernetes123SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
+func TestNutanixKubernetes121SimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewNutanix(t),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithEnvVar("NUTANIX_PROVIDER", "true"),
+	)
+	runSimpleFlow(test)
+}
 
- func TestNutanixKubernetes121SimpleFlow(t *testing.T) {
- 	test := framework.NewClusterE2ETest(
- 		t,
- 		framework.NewNutanix(t),
- 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
- 		framework.WithEnvVar("NUTANIX_PROVIDER", "true"),
- 	)
- 	runSimpleFlow(test)
- }
+func TestNutanixKubernetes122SimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewNutanix(t),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+		framework.WithEnvVar("NUTANIX_PROVIDER", "true"),
+	)
+	runSimpleFlow(test)
+}
 
- func TestNutanixKubernetes122SimpleFlow(t *testing.T) {
- 	test := framework.NewClusterE2ETest(
- 		t,
- 		framework.NewNutanix(t),
- 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
- 		framework.WithEnvVar("NUTANIX_PROVIDER", "true"),
- 	)
- 	runSimpleFlow(test)
- }
-
- func TestNutanixKubernetes123SimpleFlow(t *testing.T) {
- 	test := framework.NewClusterE2ETest(
- 		t,
- 		framework.NewNutanix(t),
- 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube123)),
- 		framework.WithEnvVar("NUTANIX_PROVIDER", "true"),
- 		framework.WithEnvVar(features.K8s123SupportEnvVar, "true"),
- 	)
- 	runSimpleFlow(test)
- }
-
+func TestNutanixKubernetes123SimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewNutanix(t),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube123)),
+		framework.WithEnvVar("NUTANIX_PROVIDER", "true"),
+	)
+	runSimpleFlow(test)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*
<pre>
cp bundle-release.yaml bin/local-bundle-release.yaml    
LOCAL_E2E_TESTS=TestNutanixKubernetes121SimpleFlow BUNDLE_MANIFEST_URL=./bundle-release.yaml make local-e2e
</pre>

fixed following error as well
<pre>
Error: initializing capi resources in cluster: warning required env not set NUTANIX_USER
    cluster.go:689: Command eksctl anywhere [create cluster -f eksa-test-d221926/cluster.yaml -v 4 --bundles-override bin/local-bundle-release.yaml] failed with error: exit status 255: Error: initializing capi resources in cluster: warning required env not set NUTANIX_USER
    cluster.go:619: Skipping VM cleanup
2022-09-08T13:53:34.045-0700	V3	e2e	Cleaning up long running container	{"name": "eksa_1662670304623182000"}
--- FAIL: TestNutanixKubernetes121SimpleFlow (109.75s)
FAIL
make: *** [local-e2e] Error 1
</pre>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

